### PR TITLE
exports copy bytes, support copy(start, end)

### DIFF
--- a/benchmark/put.js
+++ b/benchmark/put.js
@@ -106,6 +106,10 @@ suite
   bytes.reset();
   bytes.putRawString(string).array();
 })
+.add('bytes.putRawString(str).array(0, 100)', function () {
+  bytes.reset();
+  bytes.putRawString(string).array(0, 100);
+})
 
 .on('cycle', function(event) {
   benchmarks.add(event.target);
@@ -118,9 +122,6 @@ suite
 })
 .run({ 'async': false });
 
-// $ node benchmark/put.js
-//
-//
 //   node version: v0.11.12, date: Mon May 12 2014 18:25:35 GMT+0800 (CST)
 //   Starting...
 //   20 tests completed.

--- a/lib/byte.js
+++ b/lib/byte.js
@@ -399,30 +399,6 @@ ByteBuffer.prototype.readRawString = function (index, length) {
   };
 });
 
-ByteBuffer.prototype._getString = function (index, format) {
-  var moveOffset = false;
-  if (index === null || index === undefined) {
-    index = this._offset;
-    moveOffset = true;
-  }
-  var length = this.getInt(index);
-  index += 4;
-
-  if (moveOffset) {
-    this._offset += 4 + length;
-  }
-
-  if (length === 0) {
-    // empty string
-    return '';
-  }
-
-  if (format === 'c') {
-    length--;
-  }
-  return this._bytes.toString('utf8', index, index + length);
-};
-
 ByteBuffer.prototype.putString = function (index, value) {
   if (typeof value === 'undefined') {
     value = index;
@@ -452,8 +428,20 @@ ByteBuffer.prototype.toString = function () {
   return s;
 };
 
-ByteBuffer.prototype.array = function () {
-  return this._copy(0, this._offset);
+ByteBuffer.prototype.copy = ByteBuffer.prototype.array = function (start, end) {
+  if (arguments.length === 0) {
+    // copy()
+    start = 0;
+    end = this._offset;
+  } else if (arguments.length === 1) {
+    // copy(start)
+    end = this._offset;
+  }
+
+  if (end > this._offset) {
+    end = this._offset;
+  }
+  return this._copy(start, end);
 };
 
 ByteBuffer.prototype.position = function (newPosition) {

--- a/test/byte.test.js
+++ b/test/byte.test.js
@@ -488,6 +488,25 @@ describe('byte.test.js', function () {
     });
   });
 
+  describe('array(), copy()', function () {
+    it('should copy(start)', function () {
+      var bytes = ByteBuffer.allocate(8);
+      bytes.putInt(0);
+      bytes.putInt(1);
+      bytes.copy(4).should.eql(new Buffer([0, 0, 0, 1]));
+    });
+
+    it('should copy(start, end)', function () {
+      var bytes = ByteBuffer.allocate(9);
+      bytes.putInt(0);
+      bytes.putInt(1);
+      bytes.copy(0, 8).should.eql(new Buffer([0, 0, 0, 0, 0, 0, 0, 1]));
+      bytes.copy(0, 9).should.eql(new Buffer([0, 0, 0, 0, 0, 0, 0, 1]));
+      bytes.copy(0, 4).should.eql(new Buffer([0, 0, 0, 0]));
+      bytes.copy(4, 8).should.eql(new Buffer([0, 0, 0, 1]));
+    });
+  });
+
   describe('_copy()', function () {
     it('should splice < 2048 ok', function () {
       var bytes = ByteBuffer.allocate(4096);


### PR DESCRIPTION
Now `array()` alias to `copy()`
