### PR TITLE
Fix the bug of allocating insufficient space

### DIFF
--- a/lib/byte.js
+++ b/lib/byte.js
@@ -346,14 +346,24 @@ ByteBuffer.prototype._putString = function (index, value, format) {
   return this;
 };
 
-// Prints a string to the Buffer, encoded as UTF-8
+// Prints a string to the Buffer, encoded as CESU-8
 ByteBuffer.prototype.putRawString = function (index, str) {
   if (typeof index === 'string') {
     // putRawString(str)
     str = index;
     index = this._offset;
-    this._offset += Buffer.byteLength(str);
-    this._checkSize(this._offset);
+    // Note that an UTF-8 encoder will encode a character that is outside BMP
+    // as 4 bytes, yet a CESU-8 encoder will encode as 6 bytes, ergo 6 / 4 = 1.5
+    var afterSize = this._offset + Math.ceil(Buffer.byteLength(str) * 1.5);
+    if (this._size < afterSize) {
+      var old = this._size;
+      this._size = afterSize;
+      this._limit = this._size;
+      debug('allocate new Buffer (CESU-8): from %d to %d bytes', old, this._size);
+      var bytes = new Buffer(this._size);
+      this._bytes.copy(bytes, 0);
+      this._bytes = bytes;
+    }
   }
 
   if (!str || str.length === 0) {
@@ -372,10 +382,7 @@ ByteBuffer.prototype.putRawString = function (index, str) {
       this._bytes[index++] = (0x80 + (ch & 0x3f)) >>> 32;
     }
   }
-  if (index > this._offset) {
-    this._offset = index;
-  }
-  // this._bytes.write(str, index);
+  this._offset = this._size = this._limit = index;
   return this;
 };
 

--- a/lib/byte.js
+++ b/lib/byte.js
@@ -354,16 +354,7 @@ ByteBuffer.prototype.putRawString = function (index, str) {
     index = this._offset;
     // Note that an UTF-8 encoder will encode a character that is outside BMP
     // as 4 bytes, yet a CESU-8 encoder will encode as 6 bytes, ergo 6 / 4 = 1.5
-    var afterSize = this._offset + Math.ceil(Buffer.byteLength(str) * 1.5);
-    if (this._size < afterSize) {
-      var old = this._size;
-      this._size = afterSize;
-      this._limit = this._size;
-      debug('allocate new Buffer (CESU-8): from %d to %d bytes', old, this._size);
-      var bytes = new Buffer(this._size);
-      this._bytes.copy(bytes, 0);
-      this._bytes = bytes;
-    }
+    this._checkSize(this._offset + Math.ceil(Buffer.byteLength(str) * 1.5));
   }
 
   if (!str || str.length === 0) {
@@ -382,8 +373,8 @@ ByteBuffer.prototype.putRawString = function (index, str) {
       this._bytes[index++] = (0x80 + (ch & 0x3f)) >>> 32;
     }
   }
-  // index is now probably less than @_size and reflects the real length
-  this._offset = this._size = this._limit = index;
+  // index is now probably less than @_offset and reflects the real length
+  this._offset = index;
   return this;
 };
 

--- a/lib/byte.js
+++ b/lib/byte.js
@@ -382,6 +382,7 @@ ByteBuffer.prototype.putRawString = function (index, str) {
       this._bytes[index++] = (0x80 + (ch & 0x3f)) >>> 32;
     }
   }
+  // index is now probably less than @_size and reflects the real length
   this._offset = this._size = this._limit = index;
   return this;
 };

--- a/test/byte.test.js
+++ b/test/byte.test.js
@@ -508,6 +508,13 @@ describe('byte.test.js', function () {
       bytes.putRawString(str);
       bytes.toString().should.eql('<ByteBuffer ed a0 bd ed b8 80 57 77 77 e9 82 a3>');
       bytes.getRawString(0, 12).should.eql(str);
+      
+      // Construction of a special test case which triggers the bug
+      // of allocating insufficient space via _checkSize
+      var bytes = ByteBuffer.allocate(4);
+      var str = new Buffer([-19, -96, -67, -19, -72, -128]).toString();
+      bytes.putRawString(str);
+      bytes.toString().should.eql('<ByteBuffer ed a0 bd ed b8 80>');
     });
   });
 


### PR DESCRIPTION
构造特殊的测试用例触发因依赖 _checkSize 内部乘以二而分配空间不够的 bug，并进行修复
