### PR TITLE
Add support for alinode CESU-8 encoding / decoding

### DIFF
--- a/lib/byte.js
+++ b/lib/byte.js
@@ -7,6 +7,7 @@
  * Authors:
  *   fengmk2 <fengmk2@gmail.com> (http://fengmk2.github.com)
  *   dead-horse <dead_horse@qq.com> (https://github.com/dead-horse)
+ *   P.S.V.R <pmq2001@gmail.com> (https://github.com/pmq20)
  */
 
 "use strict";
@@ -25,6 +26,7 @@ var DEFAULT_SIZE = 1024;
 var BIG_ENDIAN = 1;
 var LITTLE_ENDIAN = 2;
 var MAX_INT_31 = Math.pow(2, 31);
+var CESU_8_SUPPORTED = Buffer.isEncoding('cesu-8');
 
 function ByteBuffer(options) {
   options = options || {};
@@ -356,29 +358,38 @@ ByteBuffer.prototype.putRawString = function (index, str) {
     // putRawString(str)
     str = index;
     index = this._offset;
-    // Note that an UTF-8 encoder will encode a character that is outside BMP
-    // as 4 bytes, yet a CESU-8 encoder will encode as 6 bytes, ergo 6 / 4 = 1.5
-    this._checkSize(this._offset + Math.ceil(Buffer.byteLength(str) * 1.5));
+    if (CESU_8_SUPPORTED) {
+      this._checkSize(this._offset + Buffer.byteLength(str, 'cesu-8'));
+    } else {
+      // Note that an UTF-8 encoder will encode a character that is outside BMP
+      // as 4 bytes, yet a CESU-8 encoder will encode as 6 bytes,
+      // ergo 6 / 4 = 1.5
+      this._checkSize(this._offset + Math.ceil(Buffer.byteLength(str) * 1.5));
+    }
   }
 
   if (!str || str.length === 0) {
     return this;
   }
-  for (var i = 0, len = str.length; i < len; i++) {
-    var ch = str.charCodeAt(i);
-    if (ch < 0x80) {
-      this._bytes[index++] = ch >>> 32;
-    } else if (ch < 0x800) {
-      this._bytes[index++] = (0xc0 + ((ch >> 6) & 0x1f)) >>> 32;
-      this._bytes[index++] = (0x80 + (ch & 0x3f)) >>> 32;
-    } else {
-      this._bytes[index++] = (0xe0 + ((ch >> 12) & 0xf)) >>> 32;
-      this._bytes[index++] = (0x80 + ((ch >> 6) & 0x3f)) >>> 32;
-      this._bytes[index++] = (0x80 + (ch & 0x3f)) >>> 32;
+  if (CESU_8_SUPPORTED) {
+    this._bytes.write(str, index, this._bytes.length, 'cesu-8');
+  } else {
+    for (var i = 0, len = str.length; i < len; i++) {
+      var ch = str.charCodeAt(i);
+      if (ch < 0x80) {
+        this._bytes[index++] = ch >>> 32;
+      } else if (ch < 0x800) {
+        this._bytes[index++] = (0xc0 + ((ch >> 6) & 0x1f)) >>> 32;
+        this._bytes[index++] = (0x80 + (ch & 0x3f)) >>> 32;
+      } else {
+        this._bytes[index++] = (0xe0 + ((ch >> 12) & 0xf)) >>> 32;
+        this._bytes[index++] = (0x80 + ((ch >> 6) & 0x3f)) >>> 32;
+        this._bytes[index++] = (0x80 + (ch & 0x3f)) >>> 32;
+      }
     }
+    // index is now probably less than @_offset and reflects the real length
+    this._offset = index;
   }
-  // index is now probably less than @_offset and reflects the real length
-  this._offset = index;
   return this;
 };
 
@@ -398,23 +409,28 @@ ByteBuffer.prototype.getRawString = function (index, length) {
     // getRawString() => current offset char string
     index = this._offset++;
   } else if (typeof length === 'number') {
-    var data = [];
-    for (var pos = index, end = index + length; pos < end; pos++) {
-      var ch = this._bytes[pos];
-      if (ch < 0x80) {
-        data.push(ch);
-      } else if ((ch & 0xe0) === 0xc0) {
-        var ch1 = this._bytes[++pos];
-        var v = ((ch & 0x1f) << 6) + (ch1 & 0x3f);
-        data.push(v);
-      } else if ((ch & 0xf0) === 0xe0) {
-        var ch1 = this._bytes[++pos];
-        var ch2 = this._bytes[++pos];
-        var v = ((ch & 0x0f) << 12) + ((ch1 & 0x3f) << 6) + (ch2 & 0x3f);
-        data.push(v);
+    if (CESU_8_SUPPORTED) {
+      // getRawString(index, length);
+      return this._bytes.toString('cesu-8', index, index + length);
+    } else {
+      var data = [];
+      for (var pos = index, end = index + length; pos < end; pos++) {
+        var ch = this._bytes[pos];
+        if (ch < 0x80) {
+          data.push(ch);
+        } else if ((ch & 0xe0) === 0xc0) {
+          var ch1 = this._bytes[++pos];
+          var v = ((ch & 0x1f) << 6) + (ch1 & 0x3f);
+          data.push(v);
+        } else if ((ch & 0xf0) === 0xe0) {
+          var ch1 = this._bytes[++pos];
+          var ch2 = this._bytes[++pos];
+          var v = ((ch & 0x0f) << 12) + ((ch1 & 0x3f) << 6) + (ch2 & 0x3f);
+          data.push(v);
+        }
       }
+      return String.fromCharCode.apply(String, data);
     }
-    return String.fromCharCode.apply(String, data);
   }
   return String.fromCharCode(this._bytes[index]);
 };

--- a/lib/byte.js
+++ b/lib/byte.js
@@ -359,8 +359,8 @@ ByteBuffer.prototype.putRawString = function (index, str) {
     str = index;
     index = this._offset;
     if (CESU_8_SUPPORTED) {
-      this._checkSize(this._offset + Buffer.byteLength(str, 'cesu-8'));
       this._offset += Buffer.byteLength(str, 'cesu-8')
+      this._checkSize(this._offset);
     } else {
       // Note that an UTF-8 encoder will encode a character that is outside BMP
       // as 4 bytes, yet a CESU-8 encoder will encode as 6 bytes,

--- a/lib/byte.js
+++ b/lib/byte.js
@@ -360,6 +360,7 @@ ByteBuffer.prototype.putRawString = function (index, str) {
     index = this._offset;
     if (CESU_8_SUPPORTED) {
       this._checkSize(this._offset + Buffer.byteLength(str, 'cesu-8'));
+      this._offset += Buffer.byteLength(str, 'cesu-8')
     } else {
       // Note that an UTF-8 encoder will encode a character that is outside BMP
       // as 4 bytes, yet a CESU-8 encoder will encode as 6 bytes,

--- a/test/byte.test.js
+++ b/test/byte.test.js
@@ -7,6 +7,7 @@
  * Authors:
  *   fengmk2 <fengmk2@gmail.com> (http://fengmk2.github.com)
  *   dead-horse <dead_horse@qq.com> (https://github.com/dead-horse)
+ *   P.S.V.R <pmq2001@gmail.com> (https://github.com/pmq20)
  */
 
 "use strict";


### PR DESCRIPTION
Benchmark results shows that alinode's C++ version is about 2x the performance of the JS implementation.

See also https://github.com/node-modules/byte/pull/20, https://github.com/node-modules/byte/pull/16
