### PR TITLE
Should set size and limit correctly when options.array passed in

### DIFF
--- a/lib/byte.js
+++ b/lib/byte.js
@@ -15,6 +15,7 @@
  * Module dependencies.
  */
 
+var assert = require('assert');
 var Long = require('long');
 var debug = require('debug')('byte');
 var numbers = require('./number');
@@ -33,7 +34,9 @@ function ByteBuffer(options) {
   this._limit = this._size;
   var array = options.array;
   if (array) {
+    assert(array instanceof Buffer, 'options.array should be a Buffer');
     this._bytes = array;
+    this._size = this._limit = array.length;
   } else {
     this._bytes = new Buffer(this._size);
   }

--- a/test/byte.test.js
+++ b/test/byte.test.js
@@ -26,6 +26,11 @@ describe('byte.test.js', function () {
       bytes.array().should.length(0);
       bytes.position().should.equal(0);
     });
+
+    it('should correct set size when passed array', function () {
+      var bytes = new ByteBuffer({ array: new Buffer(10) });
+      bytes.limit().should.equal(10);
+    });
   });
 
   describe('putString(), getString()', function () {


### PR DESCRIPTION
Currently, `_size` and `_limit` is incorrect when `options.array` passed in constructor unless you set it explicitly. This PR will auto set it according to the `length` of `options.array`.