### PR TITLE
refactor: improve CESU-8 encoding coding style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ results
 node_modules
 npm-debug.log
 coverage/
+profile-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
+sudo: false
 language: node_js
 node_js:
   - '0.12'
-  - '1'
-  - '2'
-  - '3'
   - '4'
-script: "npm run test-travis"
+  - '6'
+  - '8'
+script: "npm run test-travis && npm run benchmark"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/benchmark/putRawString.js
+++ b/benchmark/putRawString.js
@@ -10,18 +10,160 @@ largeStr += largeStr
 var bb = ByteBuffer.allocate(1024);
 var max = 10;
 
+// putRawString
+
 bb.putRawString(makeStr('a', 200));
-console.log('small bytes %s', bb.array().length);
+console.log('putRawString: small < 0x80 bytes %s, one char length: %d',
+  bb.array().length, 'a'.length);
+bb.reset();
+
+bb.putRawString(makeStr('ȅ', 200));
+console.log('putRawString: small < 0x800 bytes %s, one char length: %d',
+  bb.array().length, 'ȅ'.length);
+bb.reset();
+
+bb.putRawString(makeStr('𐐀', 200));
+console.log('putRawString: small >= 0x800 bytes %s, one char length: %d, maxIncreaseSize: %d, bb.size: %d',
+  bb.array().length, '𐐀'.length, makeStr('𐐀', 200).length * 3, bb._size);
+bb.reset();
+
+bb.putRawString(makeStr(String.fromCharCode(0x801), 200));
+console.log('putRawString: small = 0x801 bytes %s, one char length: %d',
+  bb.array().length, String.fromCharCode(0x801).length);
+bb.reset();
+
+bb.putRawString(makeStr('中文', 200));
+console.log('putRawString: small 中文 bytes %s, one char length: %d, maxIncreaseSize: %d, bb.size: %d',
+  bb.array().length, '中文'.length, makeStr('中文', 200).length * 3, bb._size);
+bb.reset();
+
+bb.putRawString(makeStr('\ud83c\udf3c', 200));
+console.log('putRawString: small \ud83c\udf3c bytes %s, one char length: %d, maxIncreaseSize: %d, bb.size: %d',
+  bb.array().length, '\ud83c\udf3c'.length, makeStr('\ud83c\udf3c', 200).length * 3, bb._size);
 bb.reset();
 
 bb.putRawString(makeStr(largeStr, 10));
-console.log('large bytes %s', bb.array().length);
+console.log('putRawString: large bytes %s, one char length: %d',
+  bb.array().length);
 bb.reset();
 
+// putUTF8RawString
+
+bb = ByteBuffer.allocate(2);
+bb.putUTF8RawString(makeStr('a', 200));
+console.log('putUTF8RawString: small < 0x80 bytes %s, one char length: %d',
+  bb.array().length, 'a'.length);
+bb.reset();
+
+bb.putUTF8RawString(makeStr('ȅ', 200));
+console.log('putUTF8RawString: small < 0x800 bytes %s, one char length: %d',
+  bb.array().length, 'ȅ'.length);
+bb.reset();
+
+bb.putUTF8RawString(makeStr('𐐀', 200));
+console.log('putUTF8RawString: small >= 0x800 bytes %s, one char length: %d, byteLength: %d, bb.size: %d',
+  bb.array().length, '𐐀'.length, Buffer.byteLength(makeStr('𐐀', 200)), bb._size);
+bb.reset();
+
+bb.putUTF8RawString(makeStr('中文', 200));
+console.log('putUTF8RawString: small 中文 bytes %s, one char length: %d, byteLength: %d, bb.size: %d',
+  bb.array().length, '中文'.length, Buffer.byteLength(makeStr('中文', 200)), bb._size);
+bb.reset();
+
+bb.putUTF8RawString(makeStr('\ud83c\udf3c', 200));
+console.log('putUTF8RawString: small \ud83c\udf3c bytes %s, one char length: %d, byteLength: %d, bb.size: %d',
+  bb.array().length, '\ud83c\udf3c'.length, Buffer.byteLength(makeStr('\ud83c\udf3c', 200)), bb._size);
+bb.reset();
+
+bb.putUTF8RawString(makeStr(String.fromCharCode(0x801), 200));
+console.log('putUTF8RawString: small = 0x801 bytes %s, one char length: %d',
+  bb.array().length, String.fromCharCode(0x801).length);
+bb.reset();
+
+bb.putUTF8RawString(makeStr(largeStr, 10));
+console.log('putUTF8RawString: large bytes %s, one char length: %d',
+  bb.array().length);
+bb.reset();
+
+bb = ByteBuffer.allocate(1024);
+
 var run = bench([
-  function putRawStringSmall(cb) {
+  function putRawStringSmallLessThan0x80(cb) {
     for (var i = 0; i < max; i++) {
       bb.putRawString(makeStr('a', 200));
+    }
+    bb.array();
+    bb.reset();
+    setImmediate(cb);
+  },
+  function putRawStringSmallLessThan0x800(cb) {
+    for (var i = 0; i < max; i++) {
+      bb.putRawString(makeStr('ȅ', 200));
+    }
+    bb.array();
+    bb.reset();
+    setImmediate(cb);
+  },
+  function putRawStringSmallBiggerThan0x800(cb) {
+    for (var i = 0; i < max; i++) {
+      bb.putRawString(makeStr('𐐀', 200));
+    }
+    bb.array();
+    bb.reset();
+    setImmediate(cb);
+  },
+  function putRawStringSmallChinese(cb) {
+    for (var i = 0; i < max; i++) {
+      bb.putRawString(makeStr('中文', 200));
+    }
+    bb.array();
+    bb.reset();
+    setImmediate(cb);
+  },
+  function putRawStringSmallEmoji(cb) {
+    for (var i = 0; i < max; i++) {
+      bb.putRawString(makeStr('\ud83c\udf3c', 200));
+    }
+    bb.array();
+    bb.reset();
+    setImmediate(cb);
+  },
+
+  function putUTF8RawStringSmallLessThan0x80(cb) {
+    for (var i = 0; i < max; i++) {
+      bb.putUTF8RawString(makeStr('a', 200));
+    }
+    bb.array();
+    bb.reset();
+    setImmediate(cb);
+  },
+  function putUTF8RawStringSmallLessThan0x800(cb) {
+    for (var i = 0; i < max; i++) {
+      bb.putUTF8RawString(makeStr('ȅ', 200));
+    }
+    bb.array();
+    bb.reset();
+    setImmediate(cb);
+  },
+  function putUTF8RawStringSmallBiggerThan0x800(cb) {
+    for (var i = 0; i < max; i++) {
+      bb.putUTF8RawString(makeStr('𐐀', 200));
+    }
+    bb.array();
+    bb.reset();
+    setImmediate(cb);
+  },
+  function putUTF8RawStringSmallChinese(cb) {
+    for (var i = 0; i < max; i++) {
+      bb.putUTF8RawString(makeStr('中文', 200));
+    }
+    bb.array();
+    bb.reset();
+    setImmediate(cb);
+  },
+  function putUTF8RawStringSmallEmoji(cb) {
+    for (var i = 0; i < max; i++) {
+      bb.putUTF8RawString(makeStr('\ud83c\udf3c', 200));
     }
     bb.array();
     bb.reset();

--- a/lib/byte.js
+++ b/lib/byte.js
@@ -344,7 +344,7 @@ ByteBuffer.prototype._putString = function (index, value, format) {
 
 // Prints a string to the Buffer, encoded as CESU-8
 ByteBuffer.prototype.putRawString = function (index, str) {
-  if (typeof index === 'string') {
+  if (arguments.length === 1) {
     // putRawString(str)
     str = index;
     index = this._offset;
@@ -381,16 +381,39 @@ ByteBuffer.prototype.putRawString = function (index, str) {
       this._bytes[index++] = ch;
     } else if (ch < 0x800) {
       // 0x800: 2048
-      this._bytes[index++] = (0xc0 + ((ch >> 6) & 0x1f)) >>> 32;
-      this._bytes[index++] = (0x80 + (ch & 0x3f)) >>> 32;
+      // this._bytes[index++] = (0xc0 + ((ch >> 6) & 0x1f)) >>> 32;
+      // this._bytes[index++] = (0x80 + (ch & 0x3f)) >>> 32;
+      this._bytes[index++] = (ch >>> 6) | 0xc0;
+      this._bytes[index++] = (ch & 0x3f) | 0x80; // 0x3f => 0b00111111
     } else {
-      this._bytes[index++] = (0xe0 + ((ch >> 12) & 0xf)) >>> 32;
-      this._bytes[index++] = (0x80 + ((ch >> 6) & 0x3f)) >>> 32;
-      this._bytes[index++] = (0x80 + (ch & 0x3f)) >>> 32;
+      // this._bytes[index++] = (0xe0 + ((ch >> 12) & 0xf)) >>> 32;
+      // this._bytes[index++] = (0x80 + ((ch >> 6) & 0x3f)) >>> 32;
+      // this._bytes[index++] = (0x80 + (ch & 0x3f)) >>> 32;
+      this._bytes[index++] = (ch >>> 12) | 0xe0;
+      this._bytes[index++] = ((ch >>> 6) & 0x3f) | 0x80;
+      this._bytes[index++] = (ch & 0x3f) | 0x80;
     }
   }
   // index is now probably less than @_offset and reflects the real length
   this._offset = index;
+  return this;
+};
+
+ByteBuffer.prototype.putUTF8RawString = function (index, str) {
+  var buf;
+  if (arguments.length === 1) {
+    // putUTF8RawString(str)
+    str = index;
+    index = this._offset;
+    buf = Buffer.from ? Buffer.from(str) : new Buffer(str);
+    this._checkSize(this._offset + buf.length);
+    buf.copy(this._bytes, index);
+  } else {
+    buf = Buffer.from ? Buffer.from(str) : new Buffer(str);
+    buf.copy(this._bytes, index);
+  }
+
+  this._offset = index + buf.length;
   return this;
 };
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "autod": "autod -w --prefix '^' -e benchmark && npm run cnpm",
     "cnpm": "npm install --registry=https://registry.npm.taobao.org",
     "contributors": "contributors -f plain -o AUTHORS",
-    "optimized": "node --allow-natives-syntax --trace_opt --trace_deopt test/optimized.js"
+    "optimized": "node --allow-natives-syntax --trace_opt --trace_deopt test/optimized.js",
+    "benchmark": "node benchmark/putRawString.js"
   },
   "dependencies": {
     "debug": "^2.6.6",

--- a/test/byte.test.js
+++ b/test/byte.test.js
@@ -458,7 +458,7 @@ describe('byte.test.js', function () {
     });
   });
 
-  describe('putRawString()', function () {
+  describe('putRawString(), putUTF8RawString()', function () {
     it('should put raw string', function () {
       var bytes = ByteBuffer.allocate(1);
       bytes.putRawString('hello');
@@ -469,14 +469,24 @@ describe('byte.test.js', function () {
       assert(bytes.getRawString() === 'h');
 
       bytes = ByteBuffer.allocate(1);
+      bytes.putUTF8RawString('hello');
+      bytes.putUTF8RawString(' world');
+      assert(bytes.toString() === '<ByteBuffer 68 65 6c 6c 6f 20 77 6f 72 6c 64>');
+
+      bytes = ByteBuffer.allocate(1);
       bytes.putRawString('你好');
       assert(bytes.toString() === '<ByteBuffer e4 bd a0 e5 a5 bd>');
       assert(bytes.position(0).readRawString(6) === '你好');
       bytes.putRawString(0, '我们');
       assert(bytes.toString() === '<ByteBuffer e6 88 91 e4 bb ac>');
       assert(bytes.getRawString(0, 6) === '我们');
-
       assert(bytes.readRawString(0, 6) === '我们');
+
+      bytes = ByteBuffer.allocate(1);
+      bytes.putUTF8RawString('你好');
+      assert(bytes.toString() === '<ByteBuffer e4 bd a0 e5 a5 bd>');
+      bytes.putUTF8RawString(0, '我们');
+      assert(bytes.toString() === '<ByteBuffer e6 88 91 e4 bb ac>');
 
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString('');
@@ -486,8 +496,8 @@ describe('byte.test.js', function () {
     it('should 000000000xxxxxxx (0x0000 ~ 0x007f) => 0xxxxxxx (0x00 ~ 0x7f)', function() {
       // UTF-8
       var bytes = ByteBuffer.allocate(1);
-      bytes.putString(String.fromCharCode(0x0000));
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 01 00>');
+      bytes.putUTF8RawString(String.fromCharCode(0x0000));
+      assert(bytes.toString() === '<ByteBuffer 00>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString(String.fromCharCode(0x0000));
@@ -495,8 +505,8 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString(String.fromCharCode(0x0001));
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 01 01>');
+      bytes.putUTF8RawString(String.fromCharCode(0x0001));
+      assert(bytes.toString() === '<ByteBuffer 01>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString(String.fromCharCode(0x0001));
@@ -504,8 +514,8 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString('E'); // 0x45
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 01 45>');
+      bytes.putUTF8RawString('E'); // 0x45
+      assert(bytes.toString() === '<ByteBuffer 45>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString('E');
@@ -513,8 +523,8 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString(String.fromCharCode(0x7F));
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 01 7f>');
+      bytes.putUTF8RawString(String.fromCharCode(0x7F));
+      assert(bytes.toString() === '<ByteBuffer 7f>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString(String.fromCharCode(0x7F));
@@ -525,8 +535,8 @@ describe('byte.test.js', function () {
       // UTF-8
       var bytes = ByteBuffer.allocate(1);
       bytes = ByteBuffer.allocate(1);
-      bytes.putString(String.fromCharCode(0x80));
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 02 c2 80>');
+      bytes.putUTF8RawString(String.fromCharCode(0x80));
+      assert(bytes.toString() === '<ByteBuffer c2 80>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString(String.fromCharCode(0x80));
@@ -534,8 +544,8 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString('ȅ'); // 0x0205: 517
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 02 c8 85>');
+      bytes.putUTF8RawString('ȅ'); // 0x0205: 517
+      assert(bytes.toString() === '<ByteBuffer c8 85>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString('ȅ');
@@ -543,8 +553,8 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString(String.fromCharCode(0x81));
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 02 c2 81>');
+      bytes.putUTF8RawString(String.fromCharCode(0x81));
+      assert(bytes.toString() === '<ByteBuffer c2 81>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString(String.fromCharCode(0x81));
@@ -552,8 +562,8 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString(String.fromCharCode(0x7FE));
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 02 df be>');
+      bytes.putUTF8RawString(String.fromCharCode(0x7FE));
+      assert(bytes.toString() === '<ByteBuffer df be>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString(String.fromCharCode(0x7FE));
@@ -561,8 +571,8 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString(String.fromCharCode(0x7FF));
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 02 df bf>');
+      bytes.putUTF8RawString(String.fromCharCode(0x7FF));
+      assert(bytes.toString() === '<ByteBuffer df bf>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString(String.fromCharCode(0x7FF));
@@ -573,8 +583,8 @@ describe('byte.test.js', function () {
       // UTF-8
       var bytes = ByteBuffer.allocate(1);
       bytes = ByteBuffer.allocate(1);
-      bytes.putString(String.fromCharCode(0x800));
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 03 e0 a0 80>');
+      bytes.putUTF8RawString(String.fromCharCode(0x800));
+      assert(bytes.toString() === '<ByteBuffer e0 a0 80>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString(String.fromCharCode(0x800));
@@ -582,8 +592,8 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString(String.fromCharCode(0x801));
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 03 e0 a0 81>');
+      bytes.putUTF8RawString(String.fromCharCode(0x801));
+      assert(bytes.toString() === '<ByteBuffer e0 a0 81>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString(String.fromCharCode(0x801));
@@ -591,8 +601,8 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString('𐐀'); // 0xD801 0xDC00
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 04 f0 90 90 80>');
+      bytes.putUTF8RawString('𐐀'); // 0xD801 0xDC00
+      assert(bytes.toString() === '<ByteBuffer f0 90 90 80>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString('𐐀');
@@ -600,8 +610,8 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString('\ud801\udc01'); // 0xD801 0xDC01
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 04 f0 90 90 81>');
+      bytes.putUTF8RawString('\ud801\udc01'); // 0xD801 0xDC01
+      assert(bytes.toString() === '<ByteBuffer f0 90 90 81>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString('\ud801\udc01');
@@ -609,8 +619,8 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString(String.fromCharCode(0xFFFE));
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 03 ef bf be>');
+      bytes.putUTF8RawString(String.fromCharCode(0xFFFE));
+      assert(bytes.toString() === '<ByteBuffer ef bf be>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString(String.fromCharCode(0xFFFE));
@@ -618,12 +628,25 @@ describe('byte.test.js', function () {
 
       // UTF-8
       bytes = ByteBuffer.allocate(1);
-      bytes.putString(String.fromCharCode(0xFFFF));
-      assert(bytes.toString() === '<ByteBuffer 00 00 00 03 ef bf bf>');
+      bytes.putUTF8RawString(String.fromCharCode(0xFFFF));
+      assert(bytes.toString() === '<ByteBuffer ef bf bf>');
       // CESU-8
       bytes = ByteBuffer.allocate(1);
       bytes.putRawString(String.fromCharCode(0xFFFF));
       assert(bytes.toString() === '<ByteBuffer ef bf bf>');
+    });
+
+    it('U+10000 ~ U+10FFFF', function() {
+      // https://en.wikipedia.org/wiki/UTF-8
+      // UTF-8
+      var bytes = ByteBuffer.allocate(1);
+      bytes = ByteBuffer.allocate(1);
+      bytes.putUTF8RawString('𐍈');
+      assert(bytes.toString() === '<ByteBuffer f0 90 8d 88>');
+      // CESU-8
+      bytes = ByteBuffer.allocate(1);
+      bytes.putRawString('𐍈');
+      assert(bytes.toString() === '<ByteBuffer ed a0 80 ed bd 88>');
     });
 
     it('should put emoji', function () {
@@ -639,6 +662,14 @@ describe('byte.test.js', function () {
       bytes.putRawString(str);
       assert(bytes.toString() === '<ByteBuffer 68 65 6c 6c 6f ed a0 bc ed bc bc>');
       assert.deepEqual(bytes.getRawString(0, 11), str);
+
+      var str = '\ud83c\udf3c';
+      bytes = ByteBuffer.allocate(1);
+      bytes.putRawString(str);
+      assert(bytes.toString() === '<ByteBuffer ed a0 bc ed bc bc>');
+      bytes = ByteBuffer.allocate(1);
+      bytes.putUTF8RawString(str);
+      assert(bytes.toString() === '<ByteBuffer f0 9f 8c bc>');
 
       var bytes = ByteBuffer.allocate(1);
       // java encode bytes: [-19, -96, -67, -19, -72, -128, 87, 119, 119, -23, -126, -93]


### PR DESCRIPTION
BTW: js CESU-8 encoding is faster then Buffer UTF-8 encoding

```
putRawStringSmallLessThan0x80*10000: 672.642ms
putRawStringSmallLessThan0x800*10000: 592.960ms
putRawStringSmallBiggerThan0x800*10000: 861.010ms

putUTF8RawStringSmallLessThan0x80*10000: 841.638ms
putUTF8RawStringSmallLessThan0x800*10000: 958.383ms
putUTF8RawStringSmallBiggerThan0x800*10000: 1793.470ms
```