### PR TITLE
fix: using Buffer.alloc(size) instead of new Buffer(size)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ node_js:
   - '4'
   - '6'
   - '8'
-  - '9'
+  - '10'
 script: "npm run test-travis"
 after_script: "npm install coveralls@2 && cat ./coverage/lcov.info | coveralls"

--- a/lib/byte.js
+++ b/lib/byte.js
@@ -21,7 +21,7 @@ function ByteBuffer(options) {
   if (array) {
     this._bytes = array;
   } else {
-    this._bytes = new Buffer(this._size);
+    this._bytes = allocBuffer(this._size);
   }
 }
 
@@ -57,12 +57,7 @@ ByteBuffer.prototype._checkSize = function (afterSize) {
   this._size = afterSize * 2;
   this._limit = this._size;
   debug('allocate new Buffer: from %d to %d bytes', old, this._size);
-  var bytes;
-  if (Buffer.allocUnsafe) {
-    bytes = Buffer.allocUnsafe(this._size);
-  } else {
-    bytes = new Buffer(this._size);
-  }
+  var bytes = allocBuffer(this._size);
   this._bytes.copy(bytes, 0);
   this._bytes = bytes;
 };
@@ -400,7 +395,7 @@ ByteBuffer.prototype._copy = function (start, end) {
   // if (end - start > 2048) {
   //   return this._bytes.slice(start, end);
   // }
-  var buf = new Buffer(end - start);
+  var buf = allocBuffer(end - start);
   this._bytes.copy(buf, 0, start, end);
   return buf;
 };
@@ -594,7 +589,7 @@ ByteBuffer.prototype.flip = function () {
 ByteBuffer.prototype.clear = function () {
   this._limit = this._size;
   this._offset = 0;
-  this._bytes = new Buffer(this._size);
+  this._bytes = allocBuffer(this._size);
   return this;
 }
 
@@ -636,5 +631,14 @@ ByteBuffer.prototype.checkForUnderflow = function (length) {
     throw new Error('BufferOverflowException');
   }
 };
+
+function allocBuffer(size) {
+  if (Buffer.alloc) {
+    return Buffer.alloc(size);
+  }
+  var buf = new Buffer(size);
+  buf.fill(0);
+  return buf;
+}
 
 module.exports = ByteBuffer;

--- a/test/byte.test.js
+++ b/test/byte.test.js
@@ -757,7 +757,7 @@ describe('byte.test.js', function () {
       var buf2 = new Buffer(1);
       assert.throws(function() {
         bytes.get(buf2);
-      }, 'BufferOverflowException');
+      }, null, 'BufferOverflowException');
     });
 
     it('should get(dst, offset, length) again', function () {
@@ -793,7 +793,7 @@ describe('byte.test.js', function () {
       bytes.put(0xfd);
       assert.throws(function () {
         bytes.getRawStringByStringLength(0, str.length + 1);
-      }, 'string is not valid UTF-8 encode');
+      }, null, 'string is not valid UTF-8 encode');
     });
   });
 


### PR DESCRIPTION
`new Buffer(size)` 没有 fill 0，可能会导致信息泄露。并且 node 10 里已经 deprecated，用 Buffer.alloc / Buffer.from / Buffer.allocUnsafe 代替 

https://snyk.io/vuln/npm:byte:20180512